### PR TITLE
리팩토링

### DIFF
--- a/src/Board.tsx
+++ b/src/Board.tsx
@@ -1,15 +1,13 @@
 import Cell from './Cell.tsx';
-import { type Cell as Celltype, type Map2048 } from './game.tsx';
-
-interface BoardProps {
-  BoardArray: Map2048;
-}
+import styles from './css/Board.module.css';
+import type { BoardProps } from './types/Board.d.tsx';
+import type { Cell as Celltype } from './types/game.d.tsx';
 
 const Board = ({ BoardArray }: BoardProps) => {
   return (
-    <div className="board">
+    <div className={styles.board}>
       {BoardArray.map((row: Celltype[], rowIndex: number) => (
-        <div className="row" key={rowIndex}>
+        <div className={styles.row} key={rowIndex}>
           {row.map((cellValue: Celltype, columnIndex: number) => (
             <Cell key={columnIndex} value={cellValue} />
           ))}

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -1,35 +1,17 @@
+import styles from './css/Cell.module.css';
+
 interface CellProps {
   value: number | null;
 }
 
 const Cell = ({ value }: CellProps) => {
   const getClassName = () => {
-    switch (value) {
-      case 2:
-        return 'cell cell-2';
-      case 4:
-        return 'cell cell-4';
-      case 8:
-        return 'cell cell-8';
-      case 16:
-        return 'cell cell-16';
-      case 32:
-        return 'cell cell-32';
-      case 64:
-        return 'cell cell-64';
-      case 128:
-        return 'cell cell-128';
-      case 256:
-        return 'cell cell-256';
-      case 512:
-        return 'cell cell-512';
-      case 1024:
-        return 'cell cell-1024';
-      case 2048:
-        return 'cell cell-2048';
-      default:
-        return 'cell';
-    }
+    const styledCell = value !== null ? styles[`cell-${value}`] : undefined;
+    return value !== null &&
+      styles.cell !== undefined &&
+      styledCell !== undefined
+      ? `${styles.cell} ${styledCell}`
+      : styles.cell;
   };
 
   return <div className={getClassName()}>{value !== null ? value : ''}</div>;

--- a/src/css/App.module.css
+++ b/src/css/App.module.css
@@ -1,0 +1,79 @@
+.main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .row {
+    grid-template-columns: repeat(4, 60px);
+  }
+
+  .cell {
+    width: 60px;
+    height: 60px;
+    font-size: 1.5rem;
+  }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.gameOverMessage {
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+}
+
+button {
+  margin-top: 10px;
+  padding: 10px 20px;
+  font-size: 16px;
+}
+
+.toolLine {
+  display: flex;
+  gap: 10px;
+  padding: 5px;
+  justify-content: flex-end;
+}
+
+.toolButton {
+  border: none;
+  outline: none;
+  background-color: #bbada0;
+  color: #eeeeee;
+  font-size: 24px;
+  font-weight: bold;
+  font-family: Arial, Helvetica, sans-serif;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.merged-animation {
+  animation: merge 0.5s ease forwards;
+}
+
+@keyframes merge {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}

--- a/src/css/Board.module.css
+++ b/src/css/Board.module.css
@@ -1,0 +1,15 @@
+.board {
+  display: grid;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  background-color: #bbada0;
+  border-radius: 5px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(4, 80px);
+  gap: 10px;
+}

--- a/src/css/Cell.module.css
+++ b/src/css/Cell.module.css
@@ -1,0 +1,37 @@
+.cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 80px;
+  height: 80px;
+  background-color: #eee4da;
+  color: #776e65;
+  font-size: 2rem;
+  font-weight: bold;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  text-align: center;
+  transition: background-color 0.2s ease;
+}
+
+.cell-2 {
+  background-color: #eee4da;
+}
+.cell-4 {
+  background-color: #ede0c8;
+}
+.cell-8 {
+  background-color: #f2b179;
+}
+.cell-16 {
+  background-color: #f59563;
+}
+.cell-32 {
+  background-color: #f67c5f;
+}
+.cell-64 {
+  background-color: #f65e3b;
+}
+.cell-128 {
+  background-color: #edcf72;
+}

--- a/src/game.tsx
+++ b/src/game.tsx
@@ -4,6 +4,14 @@
  * @param direction 이동 방향
  * @returns 이동 방향에 따른 결과와 이동되었는지 여부
  */
+import type {
+  Cell,
+  Direction,
+  DirectionDegreeMap,
+  Map2048,
+  MoveResult,
+} from './types/game.d.tsx';
+
 export const moveMapIn2048Rule = (
   map: Map2048,
   direction: Direction,
@@ -138,10 +146,3 @@ const revertDegreeMap: DirectionDegreeMap = {
   down: 90,
   left: 0,
 };
-
-export type Cell = number | null;
-export type Map2048 = Cell[][];
-type Direction = 'up' | 'left' | 'right' | 'down';
-type RotateDegree = 0 | 90 | 180 | 270;
-type DirectionDegreeMap = Record<Direction, RotateDegree>;
-type MoveResult = { result: Map2048; isMoved: boolean; moveScore: number };

--- a/src/types/App.d.tsx
+++ b/src/types/App.d.tsx
@@ -1,0 +1,6 @@
+import type { Map2048 } from './game.d.tsx';
+
+export interface GameState {
+  board: Map2048;
+  score: number;
+}

--- a/src/types/Board.d.tsx
+++ b/src/types/Board.d.tsx
@@ -1,0 +1,5 @@
+import type { Map2048 } from './game.d.tsx';
+
+export interface BoardProps {
+  BoardArray: Map2048;
+}

--- a/src/types/game.d.tsx
+++ b/src/types/game.d.tsx
@@ -1,0 +1,10 @@
+export type Cell = number | null;
+export type Map2048 = Cell[][];
+export type Direction = 'up' | 'left' | 'right' | 'down';
+type RotateDegree = 0 | 90 | 180 | 270;
+export type DirectionDegreeMap = Record<Direction, RotateDegree>;
+export type MoveResult = {
+  result: Map2048;
+  isMoved: boolean;
+  moveScore: number;
+};


### PR DESCRIPTION
1. Cell.tsx의 case문 축약 - 이전에는 case문을 이용해 직접 css의 클래스명을 숫자에 맞는 셀에 적용하는 방법을 사용하였으나, 조건이 많아 가독성이 떨어지고 코드가 길어지는 점을 수정하기 위해 함수형으로 직접 전달하는 방식으로 바꾸었습니다.
2. plain css를 css modules방식으로 변경 - 기존 App.css에서 전부 처리한 css방식에서 컴포넌트에 대해 css module을 두는 방식으로 변경하였습니다. 개인적으로 코드의 통일성 때문에 css module 방식을 선호합니다.
3. Movement를 case문으로 처리하지 않고 객체 매핑 방식으로 변경 - 기존에는 case문을 이용하여 동일한 코드가 여러번 반복되었으나 리팩토링을 통해 객체 매핑 방식으로 변경하였고 실행문 또한 한번만 작성하도록 바꾸었습니다. 
4. 2048 보드 순회시 for문 대신 map으로 변경 - for문을 사용하는 방식에서 간결함과 가독성, 안정성을 높이기 위해 map을 사용하는 방식으로 바꾸었습니다. 이 과정에서 if를 통한 undefined도 제거가능했습니다.
5. loadgamestorage함수에서 반복된 null check를 하나의 함수 사용 - 가독성을 높이고 추후의 재사용성을 높이기 위해 null check 부분을 하나의 함수로 분리했습니다.
6. Types 폴더 분리 - tsx파일 내에 선언되었던 type들을 독립적인 파일로 분리하여 각 파일에서 사용되는 타입들을 보기 쉽게 변경했습니다. 사용되는 타입을 보다 명확하게 알 수 잇었습니다. 지금은 user defined type이 별로 없어서 크게 체감이 되는 부분은 아니었지만 추후에 유지보수성을 위해 바꾸어 주었습니다.